### PR TITLE
Refactor CMSLink component

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -70,7 +70,12 @@ export async function Footer() {
             <h3 className="font-bold mb-3 font-heading">Our Pages</h3>
             <nav className="flex flex-col space-y-2 text-sm text-brand-white hover:text-brand-primary">
               {navItems.map(({ link }, i) => (
-                <CMSLink className="text-white" key={i} {...link} />
+                <CMSLink
+                  className="text-white"
+                  key={i}
+                  href={link.url}
+                  label={link.label}
+                />
               ))}
             </nav>
           </div>

--- a/src/components/Header/Nav.tsx
+++ b/src/components/Header/Nav.tsx
@@ -12,7 +12,7 @@ export const HeaderNav: React.FC<Props> = ({ navItems }) => {
   return (
     <nav className="flex flex-col md:flex-row gap-3 space-y-8 md:space-y-0 items-center text-xl md:text-base">
       {navItems.map(({ link }, i) => (
-        <CMSLink key={i} {...link} appearance="link" />
+        <CMSLink key={i} href={link.url} label={link.label} appearance="link" />
       ))}
     </nav>
   )

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -3,7 +3,6 @@ import { cn } from '@/utilities/ui'
 import Link from 'next/link'
 import React from 'react'
 
-import type { Page, Post } from '@/payload-types'
 
 type CMSLinkType = {
   appearance?: 'inline' | ButtonProps['variant']
@@ -11,36 +10,25 @@ type CMSLinkType = {
   className?: string
   label?: string | null
   newTab?: boolean | null
-  reference?: {
-    relationTo: 'pages' | 'posts'
-    value: Page | Post | string | number
-  } | null
+  href?: string | null
   size?: ButtonProps['size'] | null
-  type?: 'custom' | 'reference' | null
   url?: string | null
 }
 
 export const CMSLink: React.FC<CMSLinkType> = (props) => {
   const {
-    type,
     appearance = 'inline',
     children,
     className,
     label,
     newTab,
-    reference,
+    href,
     size: sizeFromProps,
     url,
   } = props
 
-  const href =
-    type === 'reference' && typeof reference?.value === 'object' && reference.value.slug
-      ? `${reference?.relationTo !== 'pages' ? `/${reference?.relationTo}` : ''}/${
-          reference.value.slug
-        }`
-      : url
-
-  if (!href) return null
+  const linkHref = href || url
+  if (!linkHref) return null
 
   const size = appearance === 'link' ? 'clear' : sizeFromProps
   const newTabProps = newTab ? { rel: 'noopener noreferrer', target: '_blank' } : {}
@@ -48,7 +36,7 @@ export const CMSLink: React.FC<CMSLinkType> = (props) => {
   /* Ensure we don't break any styles set by richText */
   if (appearance === 'inline') {
     return (
-      <Link className={cn(className)} href={href || url || ''} {...newTabProps}>
+      <Link className={cn(className)} href={linkHref || ''} {...newTabProps}>
         {label && label}
         {children && children}
       </Link>
@@ -57,7 +45,7 @@ export const CMSLink: React.FC<CMSLinkType> = (props) => {
 
   return (
     <Button asChild className={className} size={size} variant={appearance}>
-      <Link className={cn(className)} href={href || url || ''} {...newTabProps}>
+      <Link className={cn(className)} href={linkHref || ''} {...newTabProps}>
         {label && label}
         {children && children}
       </Link>


### PR DESCRIPTION
## Summary
- simplify `CMSLink` props to accept `href` instead of Payload references
- update HeaderNav and Footer to pass explicit `href`

## Testing
- `npm run build` *(fails: next not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686cf4e8e848832cbb90819b26ac5a1b