### PR TITLE
Add helper utilities for media components

### DIFF
--- a/src/cssVariables.ts
+++ b/src/cssVariables.ts
@@ -1,0 +1,9 @@
+export const cssVariables = {
+  breakpoints: {
+    sm: 640,
+    md: 768,
+    lg: 1024,
+    xl: 1280,
+    '2xl': 1376,
+  },
+};

--- a/src/utilities/getMediaUrl.ts
+++ b/src/utilities/getMediaUrl.ts
@@ -1,0 +1,4 @@
+export function getMediaUrl(path: string, cacheTag?: string): string {
+  if (!path) return '';
+  return cacheTag ? `${path}?v=${cacheTag}` : path;
+}


### PR DESCRIPTION
## Summary
- add `cssVariables` with default breakpoints
- add `getMediaUrl` helper for static media URLs

## Testing
- `npm run build` *(fails: `next` not found)*
- `npx tsc --noEmit` *(fails to find node modules)*

------
https://chatgpt.com/codex/tasks/task_e_686cf85437a8832cbcb34a8911b97502