### PR TITLE
Fix Tailwind PostCSS plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ pnpm dev
 bun dev
 ```
 
+### Tailwind CSS with PostCSS
+
+Tailwind CSS v4 requires the `@tailwindcss/postcss` plugin when used with
+PostCSS. Make sure this dependency is installed and referenced in
+`postcss.config.js`:
+
+```js
+// postcss.config.js
+module.exports = {
+  plugins: [require('@tailwindcss/postcss'), require('autoprefixer')],
+}
+```
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,2 @@
-module.exports = {
-  plugins: {
-    '@tailwindcss/postcss': {},
-    autoprefixer: {},
-  },
+module.exports = {  plugins: [require('@tailwindcss/postcss'), require('autoprefixer')],
 }


### PR DESCRIPTION
## Summary
- switch PostCSS config to require plugins directly
- document updated PostCSS snippet in README

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d9189161c832c9d21f2c594c9eb81